### PR TITLE
Fix tls-with-tokio-rustls compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_derive = "1.0.126"
 serde_bytes = "0.11.5"
 tokio = { version = "1.13.1", features = ["full"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
-tokio-rustls = { version = "0.26.4", optional = true }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "tls12", "ring"], optional = true }
 tracing = "0.1.41"
 webpki = {version = "0.22.4", optional = true }
 webpki-roots = { version = "1", optional = true }


### PR DESCRIPTION
This allows this to compile when used as below:
```
kmip-protocol = { branch = "next", git = "https://github.com/NLnetLabs/kmip-protocol.git", default-features = false, features = ["tls-with-tokio-rustls"] } 
```

Otherwise both `ring` and `aws-lc-rs` are included by `rustls` and the binary dies with the following:
```
thread 'main' (43035) panicked at /opt/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustls-0.23.32/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
See the documentation of the CryptoProvider type for more information.
```
