### PR TITLE
Add support for Opaque Objects

### DIFF
--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -206,7 +206,7 @@ pub enum AttributeValue {
 
     #[serde(rename(deserialize = "if type==DateTime"))]
     #[serde(rename(serialize = "Transparent"))]
-    DateTime(u64),
+    DateTime(i64),
     // TODO
     // #[serde(rename = "if type==Interval")]
     // Interval(??),
@@ -249,7 +249,7 @@ impl AttributeValue {
             }),
             "Operation Policy Name" => scanner.scan_text(Self::TAG).map(|s| Self::TextString(s.into())),
             "Cryptographic Usage Mask" => scanner.scan_int(Self::TAG).map(Self::Integer),
-            "Activation Date" => scanner.scan_date_time(Self::TAG).map(|s| Self::DateTime(s as u64)),
+            "Activation Date" => scanner.scan_date_time(Self::TAG).map(Self::DateTime),
             "Object Group" => scanner.scan_text(Self::TAG).map(|s| Self::ObjectGroup(s.into())),
             "Link" => {
                 let mut scanner = scanner.scan_struct(Self::TAG)?;
@@ -348,7 +348,7 @@ impl AttributeValue {
             &AttributeValue::Boolean(v) => formatter.format_bool(Self::TAG, v),
             AttributeValue::TextString(v) => formatter.format_text(Self::TAG, v),
             AttributeValue::ByteString(v) => formatter.format_bytes(Self::TAG, v),
-            &AttributeValue::DateTime(v) => formatter.format_date_time(Self::TAG, v as i64),
+            &AttributeValue::DateTime(v) => formatter.format_date_time(Self::TAG, v),
         }
     }
 }

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -790,6 +790,57 @@ impl TransparentDHPublicKey {
     }
 }
 
+/// See KMIP 1.0 section 3.2 [Name](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581174).
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename = "0x420053(0x420055,0x420054)")]
+pub struct Name(pub NameValue, pub NameType);
+
+impl FromStr for Name {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(NameValue::from_str(s)?, NameType::UninterpretedTextString))
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}", self.0))
+    }
+}
+
+impl_ttlv_serde!(struct Name(
+    value: NameValue,
+    r#type: NameType,
+) as 0x420053);
+
+/// See KMIP 1.0 section 2.2.8 [Opaque Object](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581171)
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename = "0x42005B(0x420059,0x42005A)")]
+pub struct OpaqueObject(pub OpaqueDataType, pub OpaqueDataValue);
+
+impl_ttlv_serde!(struct OpaqueObject(a: OpaqueDataType, b: OpaqueDataValue) as 0x42005B);
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
+#[serde(rename = "0x420059")]
+#[non_exhaustive]
+#[repr(u32)]
+pub enum OpaqueDataType {
+    // This doesn't actually have any values
+    // Values starting at 0x80000000 are considered extentions.
+    // This matches the assumption in PyKMIP
+    #[serde(rename = "0x80000000")]
+    None,
+}
+
+impl_ttlv_serde!(enum OpaqueDataType as 0x420059);
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename = "Transparent:0x42005A")]
+pub struct OpaqueDataValue(#[serde(with = "serde_bytes")] pub Vec<u8>);
+
+impl_ttlv_serde!(bytes OpaqueDataValue as 0x42005A);
+
 /// See KMIP 1.2 section 2.1.10 [Data](https://docs.oasis-open.org/kmip/spec/v1.2/os/kmip-spec-v1.2-os.html#_Toc395776391).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename = "Transparent:0x4200C2")]

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -144,7 +144,7 @@ impl Attribute {
         Attribute(
             AttributeName("Activation Date".into()),
             Option::<AttributeIndex>::None,
-            AttributeValue::DateTime(value),
+            AttributeValue::DateTime(value as i64),
         )
     }
 

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -12,8 +12,8 @@ use crate::ttlv::types::Tag;
 use super::common::{
     ApplicationData, ApplicationNamespace, AttributeIndex, AttributeName, AttributeValue, CompromiseOccurrenceDate,
     CryptographicAlgorithm, CryptographicLength, CryptographicParameters, CryptographicUsageMask, Data, DataLength,
-    KeyCompressionType, KeyFormatType, KeyMaterial, LinkType, LinkedObjectIdentifier, NameType, NameValue, ObjectType,
-    Operation, RevocationMessage, RevocationReasonCode, UniqueBatchItemID, UniqueIdentifier,
+    KeyCompressionType, KeyFormatType, KeyMaterial, LinkType, LinkedObjectIdentifier, Name, NameType, NameValue, ObjectType,
+    OpaqueObject, Operation, RevocationMessage, RevocationReasonCode, UniqueBatchItemID, UniqueIdentifier,
 };
 
 use super::impl_ttlv_serde;
@@ -843,57 +843,6 @@ impl_ttlv_serde!(struct PrivateKey(block: KeyBlock) as 0x420064);
 pub struct Template(pub Vec<Attribute>);
 
 impl_ttlv_serde!(struct Template(#[vec] attrs: Attribute) as 0x420090);
-
-/// See KMIP 1.0 section 2.2.8 [Opaque Object](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581171)
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename = "0x42005B(0x420059,0x42005A)")]
-pub struct OpaqueObject(pub OpaqueDataType, pub OpaqueDataValue);
-
-impl_ttlv_serde!(struct OpaqueObject(a: OpaqueDataType, b: OpaqueDataValue) as 0x42005B);
-
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
-#[serde(rename = "0x420059")]
-#[non_exhaustive]
-#[repr(u32)]
-pub enum OpaqueDataType {
-    // This doesn't actually have any values
-    // Values starting at 0x80000000 are considered extentions.
-    // This matches the assumption in PyKMIP
-    #[serde(rename = "0x80000000")]
-    None,
-}
-
-impl_ttlv_serde!(enum OpaqueDataType as 0x420059);
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename = "Transparent:0x42005A")]
-pub struct OpaqueDataValue(#[serde(with = "serde_bytes")] pub Vec<u8>);
-
-impl_ttlv_serde!(bytes OpaqueDataValue as 0x42005A);
-
-/// See KMIP 1.0 section 3.2 [Name](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581174).
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename = "0x420053(0x420055,0x420054)")]
-pub struct Name(pub NameValue, pub NameType);
-
-impl FromStr for Name {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(NameValue::from_str(s)?, NameType::UninterpretedTextString))
-    }
-}
-
-impl fmt::Display for Name {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("{}", self.0))
-    }
-}
-
-impl_ttlv_serde!(struct Name(
-    value: NameValue,
-    r#type: NameType,
-) as 0x420053);
 
 /// See KMIP 1.0 section 3.26 [Revocation Reason](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581200).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -773,8 +773,7 @@ pub enum ManagedObject {
     // SecretData(SecretData),
     // Not implemented
 
-    // OpaqueObject(OpaqueObject),
-    // Not implemented
+    OpaqueObject(OpaqueObject),
 }
 
 impl ManagedObject {
@@ -784,12 +783,11 @@ impl ManagedObject {
             ObjectType::PublicKey => PublicKey::fast_scan(scanner).map(Self::PublicKey),
             ObjectType::PrivateKey => PrivateKey::fast_scan(scanner).map(Self::PrivateKey),
             ObjectType::Template => Template::fast_scan(scanner).map(Self::Template),
+            ObjectType::OpaqueObject => OpaqueObject::fast_scan(scanner).map(Self::OpaqueObject),
 
-            ObjectType::Certificate
-            | ObjectType::SplitKey
-            | ObjectType::SecretData
-            | ObjectType::OpaqueObject
-            | ObjectType::PGPKey => unimplemented!(),
+            ObjectType::Certificate | ObjectType::SplitKey | ObjectType::SecretData | ObjectType::PGPKey => {
+                unimplemented!()
+            }
         }
     }
 
@@ -799,12 +797,11 @@ impl ManagedObject {
             ObjectType::PublicKey => PublicKey::fast_scan_opt(scanner).map(|s| s.map(Self::PublicKey)),
             ObjectType::PrivateKey => PrivateKey::fast_scan_opt(scanner).map(|s| s.map(Self::PrivateKey)),
             ObjectType::Template => Template::fast_scan_opt(scanner).map(|s| s.map(Self::Template)),
+            ObjectType::OpaqueObject => OpaqueObject::fast_scan_opt(scanner).map(|s| s.map(Self::OpaqueObject)),
 
-            ObjectType::Certificate
-            | ObjectType::SplitKey
-            | ObjectType::SecretData
-            | ObjectType::OpaqueObject
-            | ObjectType::PGPKey => unimplemented!(),
+            ObjectType::Certificate | ObjectType::SplitKey | ObjectType::SecretData | ObjectType::PGPKey => {
+                unimplemented!()
+            }
         }
     }
 
@@ -814,6 +811,7 @@ impl ManagedObject {
             ManagedObject::PublicKey(this) => this.format(formatter),
             ManagedObject::PrivateKey(this) => this.format(formatter),
             ManagedObject::Template(this) => this.format(formatter),
+            ManagedObject::OpaqueObject(this) => this.format(formatter),
         }
     }
 }
@@ -845,6 +843,33 @@ impl_ttlv_serde!(struct PrivateKey(block: KeyBlock) as 0x420064);
 pub struct Template(pub Vec<Attribute>);
 
 impl_ttlv_serde!(struct Template(#[vec] attrs: Attribute) as 0x420090);
+
+/// See KMIP 1.0 section 2.2.8 [Opaque Object](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581171)
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename = "0x42005B(0x420059,0x42005A)")]
+pub struct OpaqueObject(pub OpaqueDataType, pub OpaqueDataValue);
+
+impl_ttlv_serde!(struct OpaqueObject(a: OpaqueDataType, b: OpaqueDataValue) as 0x42005B);
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[serde(rename = "0x420059")]
+#[non_exhaustive]
+#[repr(u32)]
+pub enum OpaqueDataType {
+    // This doesn't actually have any values
+    // Values starting at 0x80000000 are considered extentions.
+    // This matches the assumption in PyKMIP
+    #[serde(rename = "0x80000000")]
+    None,
+}
+
+impl_ttlv_serde!(enum OpaqueDataType as 0x420059);
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename = "Transparent:0x42005A")]
+pub struct OpaqueDataValue(#[serde(with = "serde_bytes")] pub Vec<u8>);
+
+impl_ttlv_serde!(bytes OpaqueDataValue as 0x42005A);
 
 /// See KMIP 1.0 section 3.2 [Name](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581174).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -11,7 +11,7 @@ use crate::types::common::CryptographicLength;
 
 use super::common::{
     AttributeIndex, AttributeName, AttributeValue, CertificateType, CryptographicAlgorithm, KeyCompressionType,
-    KeyFormatType, KeyMaterial, NameType, NameValue, ObjectType, Operation, UniqueBatchItemID, UniqueIdentifier,
+    KeyFormatType, KeyMaterial, Name, ObjectType, OpaqueObject, Operation, UniqueBatchItemID, UniqueIdentifier,
 };
 
 use super::impl_ttlv_serde;
@@ -161,8 +161,8 @@ pub enum ManagedObject {
     // #[serde(rename = "if 0x420057==0x00000007")]
     // SecretData(SecretData),
 
-    // #[serde(rename = "if 0x420057==0x00000008")]
-    // OpaqueObject(OpaqueObject),
+    #[serde(rename = "if 0x420057==0x00000008")]
+    OpaqueObject(OpaqueObject),
 }
 
 impl fmt::Display for ManagedObject {
@@ -172,6 +172,7 @@ impl fmt::Display for ManagedObject {
             ManagedObject::SymmetricKey(_) => write!(f, "SymmetricKey"),
             ManagedObject::PublicKey(_) => write!(f, "PublicKey"),
             ManagedObject::PrivateKey(_) => write!(f, "PrivateKey"),
+            ManagedObject::OpaqueObject(_) => write!(f, "OpaqueObject"),
         }
     }
 }
@@ -214,19 +215,6 @@ pub struct PrivateKey {
 }
 
 impl_ttlv_serde!(struct PrivateKey { key_block: KeyBlock } as 0x420064);
-
-///  See KMIP 1.0 section 3.2 [Name](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581174).
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename = "0x420053")]
-pub struct Name {
-    pub name: NameValue,
-    pub r#type: NameType,
-}
-
-impl_ttlv_serde!(struct Name {
-    name: NameValue,
-    r#type: NameType,
-} as 0x420053);
 
 ///  See KMIP 1.0 section 4.1 [Create](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581209).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]


### PR DESCRIPTION
This adds support for the Opaque Object type.  Tested against PyKMIP.

This also fixes Date-Time decoding, as Date-Time is encoded as `i64` on the wire.

