### PR TITLE
Remove dependency enum-display-derive.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bb8 = { version = "0.9.0", optional = true }
 cfg-if = "1.0.0"
-enum-display-derive = "0.1.1"
 bitflags = "2.7.0"
 kmip-ttlv = { git = "https://github.com/NLnetLabs/kmip-ttlv", branch = "next", version = "0.4.0", default-features = false }
 hex = { version = "0.4.3" }

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -1,8 +1,7 @@
 //! Rust types common to both serialization of KMIP requests and deserialization KMIP responses.
-use std::fmt::Display;
+use std::fmt;
 use std::str::FromStr;
 
-use enum_display_derive::Display;
 use enum_ordinalize::Ordinalize;
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
@@ -393,8 +392,8 @@ pub enum KeyMaterial {
     Structure(#[serde(with = "serde_bytes")] Vec<u8>), // All other transparent key types which we don't support yet
 }
 
-impl Display for KeyMaterial {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for KeyMaterial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             KeyMaterial::Bytes(_) => write!(f, "Bytes"),
             KeyMaterial::TransparentSymmetricKey(_) => write!(f, "TransparentSymmetricKey"),
@@ -831,8 +830,8 @@ impl_ttlv_serde!(text UniqueIdentifier as 0x420094);
 #[serde(rename = "Transparent:0x420055")]
 pub struct NameValue(pub String);
 
-impl std::fmt::Display for NameValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for NameValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }
 }
@@ -848,7 +847,7 @@ impl FromStr for NameValue {
 impl_ttlv_serde!(text NameValue as 0x420055);
 
 /// See KMIP 1.0 section 3.3 [Object Type](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581175).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420057")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -883,10 +882,28 @@ pub enum ObjectType {
     PGPKey,
 }
 
+impl fmt::Display for ObjectType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::Certificate => "Certificate",
+                Self::SymmetricKey => "SymmetricKey",
+                Self::PublicKey => "PublicKey",
+                Self::PrivateKey => "PrivateKey",
+                Self::SplitKey => "SplitKey",
+                Self::Template => "Template",
+                Self::SecretData => "SecretData",
+                Self::OpaqueObject => "OpaqueObject",
+                Self::PGPKey => "PGPKey",
+            }
+        )
+    }
+}
+
 impl_ttlv_serde!(enum ObjectType as 0x420057);
 
 /// See KMIP 1.0 section 3.4 [Cryptographic Algorithm Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581176).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420028")]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
@@ -972,6 +989,41 @@ pub enum CryptographicAlgorithm {
 }
 
 impl_ttlv_serde!(enum CryptographicAlgorithm as 0x420028);
+
+impl fmt::Display for CryptographicAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::DES => "DES",
+                Self::TRIPLE_DES => "TRIPLE_DES",
+                Self::AES => "AES",
+                Self::RSA => "RSA",
+                Self::DSA => "DSA",
+                Self::ECDSA => "ECDSA",
+                Self::HMAC_SHA1 => "HMAC_SHA1",
+                Self::HMAC_SHA224 => "HMAC_SHA224",
+                Self::HMAC_SHA256 => "HMAC_SHA256",
+                Self::HMAC_SHA384 => "HMAC_SHA384",
+                Self::HMAC_SHA512 => "HMAC_SHA512",
+                Self::HMAC_MD5 => "HMAC_MD5",
+                Self::DH => "DH",
+                Self::ECDH => "ECDH",
+                Self::ECMQV => "ECMQV",
+                Self::Blowfish => "Blowfish",
+                Self::Camellia => "Camellia",
+                Self::CAST5 => "CAST5",
+                Self::IDEA => "IDEA",
+                Self::MARS => "MARS",
+                Self::RC2 => "RC2",
+                Self::RC4 => "RC4",
+                Self::RC5 => "RC5",
+                Self::SKIPJACK => "SKIPJACK",
+                Self::Twofish => "Twofish",
+                Self::EC => "EC",
+            }
+        )
+    }
+}
 
 /// See KMIP 1.0 section 3.5 [Cryptographic Length](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581177).
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -1376,7 +1428,7 @@ impl PartialEq<Vec<u8>> for &UniqueBatchItemID {
 impl_ttlv_serde!(bytes UniqueBatchItemID as 0x420093);
 
 /// See KMIP 1.0 section 9.1.3.2.2 [Key Compression Type Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Ref241603856).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420041")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -1396,8 +1448,29 @@ pub enum KeyCompressionType {
 
 impl_ttlv_serde!(enum KeyCompressionType as 0x420041);
 
+impl fmt::Display for KeyCompressionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::ECPUblicKeyTypeUncompressed => {
+                    "ECPUblicKeyTypeUncompressed"
+                }
+                Self::ECPUblicKeyTypeX962CompressedPrime => {
+                    "ECPUblicKeyTypeX962CompressedPrime"
+                }
+                Self::ECPUblicKeyTypeX962CompressedChar2 => {
+                    "ECPUblicKeyTypeX962CompressedChar2"
+                }
+                Self::ECPUblicKeyTypeX962Hybrid => {
+                    "ECPUblicKeyTypeX962Hybrid"
+                }
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.3 [Key Format Type Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Ref241992670).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420042")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -1462,8 +1535,48 @@ pub enum KeyFormatType {
 
 impl_ttlv_serde!(enum KeyFormatType as 0x420042);
 
+impl fmt::Display for KeyFormatType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::Raw => "Raw",
+                Self::Opaque => "Opaque",
+                Self::PKCS1 => "PKCS1",
+                Self::PKCS8 => "PKCS8",
+                Self::X509 => "X509",
+                Self::ECPrivateKey => "ECPrivateKey",
+                Self::TransparentSymmetricKey => "TransparentSymmetricKey",
+                Self::TransparentDSAPrivateKey => "TransparentDSAPrivateKey",
+                Self::TransparentDSAPublicKey => "TransparentDSAPublicKey",
+                Self::TransparentRSAPublicKey => "TransparentRSAPublicKey",
+                Self::TransparentRSAPrivateKey => "TransparentRSAPrivateKey",
+                Self::TransparentDHPrivateKey => "TransparentDHPrivateKey",
+                Self::TransparentDHPublicKey => "TransparentDHPublicKey",
+                Self::TransparentECDSAPrivateKey => {
+                    "TransparentECDSAPrivateKey"
+                }
+                Self::TransparentECDSAPublicKey => {
+                    "TransparentECDSAPublicKey"
+                }
+                Self::TransparentECHDPrivateKey => {
+                    "TransparentECHDPrivateKey"
+                }
+                Self::TransparentECDHPublicKey => {
+                    "TransparentECDHPublicKey"
+                }
+                Self::TransparentECMQVPrivateKey => {
+                    "TransparentECMQVPrivateKey"
+                }
+                Self::TransparentECMQVPublicKey => {
+                    "TransparentECMQVPublicKey"
+                }
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.5 [Padding Method Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc236497874).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420075")]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
@@ -1517,8 +1630,32 @@ pub enum RecommendedCurve {
 
 impl_ttlv_serde!(enum RecommendedCurve as 0x420075);
 
+impl fmt::Display for RecommendedCurve {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::P_192 => "P_192",
+                Self::K_163 => "K_163",
+                Self::B_163 => "B_163",
+                Self::P_224 => "P_224",
+                Self::K_233 => "K_233",
+                Self::B_233 => "B_233",
+                Self::P_256 => "P_256",
+                Self::K_283 => "K_283",
+                Self::B_283 => "B_283",
+                Self::P_384 => "P_384",
+                Self::K_409 => "K_409",
+                Self::B_409 => "B_409",
+                Self::P_521 => "P_521",
+                Self::K_571 => "K_571",
+                Self::B_571 => "B_571",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.6 [Certificate Type Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Ref241994296).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x42001D")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -1532,8 +1669,19 @@ pub enum CertificateType {
 
 impl_ttlv_serde!(enum CertificateType as 0x42001D);
 
+impl fmt::Display for CertificateType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::X509 => "X509",
+                Self::PGP => "PGP",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.2 section 9.1.3.2.7 [Digital Signature Algorithm Enumeration](https://docs.oasis-open.org/kmip/spec/v1.2/os/kmip-spec-v1.2-os.html#_Ref306812211).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x4200AE")]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
@@ -1590,8 +1738,47 @@ pub enum DigitalSignatureAlgorithm {
 
 impl_ttlv_serde!(enum DigitalSignatureAlgorithm as 0x4200AE);
 
+impl fmt::Display for DigitalSignatureAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::MD2WithRSAEncryption_PKCS1_v1_5 => {
+                    "MD2WithRSAEncryption_PKCS1_v1_5"
+                }
+                Self::MD5WithRSAEncryption_PKCS1_v1_5 => {
+                    "MD5WithRSAEncryption_PKCS1_v1_5"
+                }
+                Self::SHA1WithRSAEncryption_PKCS1_v1_5 => {
+                    "SHA1WithRSAEncryption_PKCS1_v1_5"
+                }
+                Self::SHA224WithRSAEncryption_PKCS1_v1_5 => {
+                    "SHA224WithRSAEncryption_PKCS1_v1_5"
+                }
+                Self::SHA256WithRSAEncryption_PKCS1_v1_5 => {
+                    "SHA256WithRSAEncryption_PKCS1_v1_5"
+                }
+                Self::SHA384WithRSAEncryption_PKCS1_v1_5 => {
+                    "SHA384WithRSAEncryption_PKCS1_v1_5"
+                }
+                Self::SHA512WithRSAEncryption_PKCS1_v1_5 => {
+                    "SHA512WithRSAEncryption_PKCS1_v1_5"
+                }
+                Self::RSASSA_PSS_PKCS1_v1_5 => "RSASSA_PSS_PKCS1_v1_5",
+                Self::DSAWithSHA1 => "DSAWithSHA1",
+                Self::DSAWithSHA224 => "DSAWithSHA224",
+                Self::DSAWithSHA256 => "DSAWithSHA256",
+                Self::ECDSAWithSHA1 => "ECDSAWithSHA1",
+                Self::ECDSAWithSHA224 => "ECDSAWithSHA224",
+                Self::ECDSAWithSHA256 => "ECDSAWithSHA256",
+                Self::ECDSAWithSHA384 => "ECDSAWithSHA384",
+                Self::ECDSAWithSHA512 => "ECDSAWithSHA512",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.10 [Name Type Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262582060).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420054")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -1605,8 +1792,19 @@ pub enum NameType {
 
 impl_ttlv_serde!(enum NameType as 0x420054);
 
+impl fmt::Display for NameType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::UninterpretedTextString => "UninterpretedTextString",
+                Self::URI => "URI",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.13 [Block Cipher Mode Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc236497881).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420011")]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
@@ -1666,8 +1864,34 @@ pub enum BlockCipherMode {
 
 impl_ttlv_serde!(enum BlockCipherMode as 0x420011);
 
+impl fmt::Display for BlockCipherMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::CBC =>  "CBC",
+                Self::ECB =>  "ECB",
+                Self::PCBC =>  "PCBC",
+                Self::CFB =>  "CFB",
+                Self::OFB =>  "OFB",
+                Self::CTR =>  "CTR",
+                Self::CMAC =>  "CMAC",
+                Self::CCM =>  "CCM",
+                Self::GCM =>  "GCM",
+                Self::CBC_MAC =>  "CBC_MAC",
+                Self::XTS =>  "XTS",
+                Self::AESKeyWrapPadding =>  "AESKeyWrapPadding",
+                Self::NISTKeyWrap =>  "NISTKeyWrap",
+                Self::X9_102_AESKW =>  "X9_102_AESKW",
+                Self::X9_102_TDKW =>  "X9_102_TDKW",
+                Self::X9_102_AKW1 =>  "X9_102_AKW1",
+                Self::X9_102_AKW2 =>  "X9_102_AKW2",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.14 [Padding Method Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc236497883).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x42005F")]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
@@ -1706,8 +1930,27 @@ pub enum PaddingMethod {
 
 impl_ttlv_serde!(enum PaddingMethod as 0x42005F);
 
+impl fmt::Display for PaddingMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::None => "None",
+                Self::OAEP => "OAEP",
+                Self::PKCS5 => "PKCS5",
+                Self::SSL3 => "SSL3",
+                Self::Zeros => "Zeros",
+                Self::ANSI_X9_23 => "ANSI_X9_23",
+                Self::ISO_10126 => "ISO_10126",
+                Self::PKCS1_v1_5 => "PKCS1_v1_5",
+                Self::X9_31 => "X9_31",
+                Self::PSS => "PSS",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.15 [Hashing Algorithm Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc236497883).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420038")]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
@@ -1749,8 +1992,28 @@ pub enum HashingAlgorithm {
 
 impl_ttlv_serde!(enum HashingAlgorithm as 0x420038);
 
+impl fmt::Display for HashingAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::MD2 => "MD2",
+                Self::MD4 => "MD4",
+                Self::MD5 => "MD5",
+                Self::SHA1 => "SHA1",
+                Self::SHA224 => "SHA224",
+                Self::SHA256 => "SHA256",
+                Self::SHA384 => "SHA384",
+                Self::SHA512 => "SHA512",
+                Self::RIPEMD160 => "RIPEMD160",
+                Self::Tiger => "Tiger",
+                Self::Whirlpool => "Whirlpool",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.15 [Key Role Type Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc236497884).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420083")]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
@@ -1822,8 +2085,38 @@ pub enum KeyRoleType {
 
 impl_ttlv_serde!(enum KeyRoleType as 0x420083);
 
+impl fmt::Display for KeyRoleType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::BDK => "BDK",
+                Self::CVK => "CVK",
+                Self::DEK => "DEK",
+                Self::MKAC => "MKAC",
+                Self::MKSMC => "MKSMC",
+                Self::MKSMI => "MKSMI",
+                Self::MKDAC => "MKDAC",
+                Self::MKDN => "MKDN",
+                Self::MKCP => "MKCP",
+                Self::MKOTH => "MKOTH",
+                Self::KEK => "KEK",
+                Self::MAC16609 => "MAC16609",
+                Self::MAC97971 => "MAC97971",
+                Self::MAC97972 => "MAC97972",
+                Self::MAC97973 => "MAC97973",
+                Self::MAC97974 => "MAC97974",
+                Self::MAC97975 => "MAC97975",
+                Self::ZPK => "ZPK",
+                Self::PVKIBM => "PVKIBM",
+                Self::PVKPVV => "PVKPVV",
+                Self::PVKOTH => "PVKOTH",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.17 [State Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262582066).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x42008D")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -1849,8 +2142,23 @@ pub enum State {
 
 impl_ttlv_serde!(enum State as 0x42008D);
 
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::PreActive => "PreActive",
+                Self::Active => "Active",
+                Self::Deactivated => "Deactivated",
+                Self::Compromised => "Compromised",
+                Self::Destroyed => "Destroyed",
+                Self::DestroyedCompromised => "DestroyedCompromised",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.18 [Revocation Reason Code Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Ref241996204).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420082")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -1879,8 +2187,24 @@ pub enum RevocationReasonCode {
 
 impl_ttlv_serde!(enum RevocationReasonCode as 0x420082);
 
+impl fmt::Display for RevocationReasonCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::Unspecified => "Unspecified",
+                Self::KeyCompromise => "KeyCompromise",
+                Self::CACompromise => "CACompromise",
+                Self::AffiliationChanged => "AffiliationChanged",
+                Self::Superseded => "Superseded",
+                Self::CessationOfOperation => "CessationOfOperation",
+                Self::PrivilegeWithdrawn => "PrivilegeWithdrawn",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.19 [Link Type Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262582069).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x42004B")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -1909,8 +2233,24 @@ pub enum LinkType {
 
 impl_ttlv_serde!(enum LinkType as 0x42004B);
 
+impl fmt::Display for LinkType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::CertificateLink => "CertificateLink",
+                Self::PublicKeyLink => "PublicKeyLink",
+                Self::PrivateKeyLink => "PrivateKeyLink",
+                Self::DerivationBaseObjectLink => "DerivationBaseObjectLink",
+                Self::DerivedKeyLink => "DerivedKeyLink",
+                Self::ReplacementObjectLink => "ReplacementObjectLink",
+                Self::ReplacedObjectLink => "ReplacedObjectLink",
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.26 [Operation Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc236497894).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x42005C")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -2043,6 +2383,56 @@ pub enum Operation {
 }
 
 impl_ttlv_serde!(enum Operation as 0x42005C);
+
+impl fmt::Display for Operation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::Create => "Create",
+                Self::CreateKeyPair => "CreateKeyPair",
+                Self::Register => "Register",
+                Self::Rekey => "Rekey",
+                Self::DeriveKey => "DeriveKey",
+                Self::Certify => "Certify",
+                Self::Recertify => "Recertify",
+                Self::Locate => "Locate",
+                Self::Check => "Check",
+                Self::Get => "Get",
+                Self::GetAttributes => "GetAttributes",
+                Self::GetAttributeList => "GetAttributeList",
+                Self::AddAttribute => "AddAttribute",
+                Self::ModifyAttribute => "ModifyAttribute",
+                Self::DeleteAttribute => "DeleteAttribute",
+                Self::ObtainLease => "ObtainLease",
+                Self::GetUsageAllocation => "GetUsageAllocation",
+                Self::Activate => "Activate",
+                Self::Revoke => "Revoke",
+                Self::Destroy => "Destroy",
+                Self::Archive => "Archive",
+                Self::Recover => "Recover",
+                Self::Validate => "Validate",
+                Self::Query => "Query",
+                Self::Cancel => "Cancel",
+                Self::Poll => "Poll",
+                Self::Notify => "Notify",
+                Self::Put => "Put",
+                Self::RekeyKeyPair => "RekeyKeyPair",
+                Self::DiscoverVersions => "DiscoverVersions",
+                Self::Encrypt => "Encrypt",
+                Self::Decrypt => "Decrypt",
+                Self::Sign => "Sign",
+                Self::SignatureVerify => "SignatureVerify",
+                Self::MAC => "MAC",
+                Self::MACVerify => "MACVerify",
+                Self::RNGRetrieve => "RNGRetrieve",
+                Self::RNGSeed => "RNGSeed",
+                Self::Hash => "Hash",
+                Self::CreateSplitKey => "CreateSplitKey",
+                Self::JoinSplitKey => "JoinSplitKey",
+            }
+        )
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -1,7 +1,7 @@
 //! Rust types for sserializing KMIP requests.
-use std::{fmt::Display, ops::Deref, str::FromStr};
+use std::fmt;
+use std::{ops::Deref, str::FromStr};
 
-use enum_display_derive::Display;
 use enum_ordinalize::Ordinalize;
 use serde_derive::{Deserialize, Serialize};
 
@@ -500,7 +500,7 @@ impl_ttlv_serde!(struct Credential as 0x420023 {
 });
 
 /// See KMIP 1.0 section 2.1.2 [Credential](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581156).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420024")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -510,6 +510,16 @@ pub enum CredentialType {
 }
 
 impl_ttlv_serde!(enum CredentialType as 0x420024);
+
+impl fmt::Display for CredentialType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::UsernameAndPassword => "UsernameAndPassword"
+            }
+        )
+    }
+}
 
 /// See KMIP 1.0 section 2.1.2 [Credential](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581156).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -849,8 +859,8 @@ impl FromStr for Name {
     }
 }
 
-impl std::fmt::Display for Name {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("{}", self.0))
     }
 }
@@ -1504,7 +1514,7 @@ impl RequestPayload {
 }
 
 /// See KMIP 1.0 section 9.1.3.2.4 [Wrapping Method Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Ref241993348).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x42009E")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -1527,8 +1537,22 @@ pub enum WrappingMethod {
 
 impl_ttlv_serde!(enum WrappingMethod as 0x42009E);
 
+impl fmt::Display for WrappingMethod {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::Encrypt => "Encrypt",
+                Self::MACSign => "MACSign",
+                Self::EncryptThenMACSign => "EncryptThenMACSign",
+                Self::MACSignThenEncrypt => "MACSignThenEncrypt",
+                Self::TR31 => "TR31"
+            }
+        )
+    }
+}
+
 /// See KMIP 1.0 section 9.1.3.2.23 [Query Function Enumeration](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Ref242030554).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x420074")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -1545,3 +1569,16 @@ pub enum QueryFunction {
 }
 
 impl_ttlv_serde!(enum QueryFunction as 0x420074);
+
+impl fmt::Display for QueryFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::QueryOperations => "QueryOperations",
+                Self::QueryObjects => "QueryObjects",
+                Self::QueryServerInformation => "QueryServerInformation",
+            }
+        )
+    }
+}
+

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -1,9 +1,8 @@
 //! Rust types for deserializing KMIP responses.
+use std::fmt;
+
 use enum_ordinalize::Ordinalize;
 use serde_derive::{Deserialize, Serialize};
-
-use enum_display_derive::Display;
-use std::fmt::Display;
 
 use crate::ttlv::fast_scan::{FastScanError, FastScanner};
 use crate::ttlv::format::{FormatResult, Formatter};
@@ -166,8 +165,8 @@ pub enum ManagedObject {
     // OpaqueObject(OpaqueObject),
 }
 
-impl Display for ManagedObject {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ManagedObject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ManagedObject::Certificate(_) => write!(f, "Certificate"),
             ManagedObject::SymmetricKey(_) => write!(f, "SymmetricKey"),
@@ -429,7 +428,7 @@ pub struct ProtocolVersion {
 }
 
 ///  See KMIP 1.0 section 6.9 [Result Status](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581247).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x42007F")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -449,8 +448,21 @@ pub enum ResultStatus {
 
 impl_ttlv_serde!(enum ResultStatus as 0x42007F);
 
+impl fmt::Display for ResultStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::Success => "Success",
+                Self::OperationFailed => "OperationFailed",
+                Self::OperationPending => "OperationPending",
+                Self::OperationUndone => "OperationUndone",
+            }
+        )
+    }
+}
+
 ///  See KMIP 1.0 section 6.10 [Result Reason](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581248).
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Display, PartialEq, Eq, Ordinalize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Ordinalize)]
 #[serde(rename = "0x42007E")]
 #[non_exhaustive]
 #[repr(u32)]
@@ -511,6 +523,41 @@ pub enum ResultReason {
 }
 
 impl_ttlv_serde!(enum ResultReason as 0x42007E);
+
+impl fmt::Display for ResultReason {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(
+            match self {
+                Self::ItemNotFound => "ItemNotFound",
+                Self::ResponseTooLarge => "ResponseTooLarge",
+                Self::AuthenticationNotSuccessful => {
+                    "AuthenticationNotSuccessful"
+                }
+                Self::InvalidMessage => "InvalidMessage",
+                Self::OperationNotSupported => "OperationNotSupported",
+                Self::MissingData => "MissingData",
+                Self::InvalidField => "InvalidField",
+                Self::FeatureNotSupported => "FeatureNotSupported",
+                Self::OperationCanceledByRequester => {
+                    "OperationCanceledByRequester"
+                }
+                Self::CryptographicFailure => "CryptographicFailure",
+                Self::IllegalOperation => "IllegalOperation",
+                Self::PermissionDenied => "PermissionDenied",
+                Self::ObjectArchived => "ObjectArchived",
+                Self::IndexOutOfBounds => "IndexOutOfBounds",
+                Self::ApplicationNamespaceNotSupported => {
+                    "ApplicationNamespaceNotSupported"
+                }
+                Self::KeyFormatTypeNotSupported => "KeyFormatTypeNotSupported",
+                Self::KeyCompressionTypeNotSupported => {
+                    "KeyCompressionTypeNotSupported"
+                }
+                Self::GeneralFailure => "GeneralFailure",
+            }
+        )
+    }
+}
 
 ///  See KMIP 1.0 section 6.16 [Message Extension](https://docs.oasis-open.org/kmip/spec/v1.0/os/kmip-spec-1.0-os.html#_Toc262581254).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]


### PR DESCRIPTION
This PR removes the dependency of enum-display-derive by manually implementing the `Display` impls for the enums. I tried making a macro, but all the attributes and decorations on the enums and variants just made it too annoying. Since those enums are unlikely to change much, I think this is fine.™